### PR TITLE
update to cursive-0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ keywords = ["cursive", "hexview"]
 license = "MIT"
 
 [dependencies]
-cursive = { version = "0.14", default-features = false }
+cursive = { version = "0.15", default-features = false }
 itertools = "0.8"
 
 [dev-dependencies]
-cursive = "0.14"
+cursive = "0.15"
 
 [badges.travis-ci]
 repository="hellow554/cursive_hexview"

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -2,11 +2,10 @@ extern crate cursive;
 extern crate cursive_hexview;
 
 use cursive::views::{Dialog, DummyView, LinearLayout, TextView};
-use cursive::Cursive;
 use cursive_hexview::{DisplayState, HexView};
 
 fn main() {
-    let mut cur = Cursive::default();
+    let mut cur = cursive::default();
     let explanation = TextView::new("Use the keys + - ↑ ↓ ← → 0-9 a-f for the HexView.\nUse q to exit.");
     let view = HexView::new().display_state(DisplayState::Editable);
 

--- a/examples/hexdump.rs
+++ b/examples/hexdump.rs
@@ -2,7 +2,6 @@ extern crate cursive;
 extern crate cursive_hexview;
 
 use cursive::views::{Dialog, DummyView, LinearLayout, TextView};
-use cursive::Cursive;
 use cursive_hexview::{DisplayState, HexView};
 use std::env;
 use std::fs::File;
@@ -22,7 +21,7 @@ fn main() {
         .expect("Please provide the file to read from as first argument");
     let path = Path::new(&arg);
 
-    let mut cur = Cursive::default();
+    let mut cur = cursive::default();
     let explanation = TextView::new("Use the keys ↑ ↓ ← → to navigate around.\nUse q to exit.");
     let view = HexView::new_from_iter(read_file(path).expect("Cannot read file")).display_state(DisplayState::Enabled);
 


### PR DESCRIPTION
Updated dependencies to use version 0.15 of cursive. 

I also realised that the toml declares version 0.2 of this crate but the readme says to import 0.3, so I guess the 0.3 has been pushed to crates.io but the code is not updated on github.

I found this discussion https://github.com/gyscos/Cursive/issues/175 and I was having the same problem, the examples work fine but when including in my project (which has other components that depend on cursive-0.15) then it was complaining that HexView doesn't implement ViewWrapper.