### PR TITLE
Update to cursive-core 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cursive", "hexview"]
 license = "MIT"
 
 [dependencies]
-cursive_core = { version = "0.4" }
+cursive_core = "0.4"
 itertools = "0.11"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ keywords = ["cursive", "hexview"]
 license = "MIT"
 
 [dependencies]
-cursive = { version = "0.20", default-features = false }
+cursive_core = { version = "0.4" }
 itertools = "0.11"
 
 [dev-dependencies]
+cursive = "0.21"
 
 [badges.travis-ci]
 repository="hellow554/cursive_hexview"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! | <kbd>-</kbd>                        | Decrease the amount of data by one. Any data that will leave the viewable area, will be permanantly lost.                                                                                                                                              |
 //! | <kbd>0-9</kbd>, <kbd>a-f</kbd>      | Set the nibble under the cursor to the corresponding hex value. Note, that this is only available in the editable state, see [`DisplayState`](enum.DisplayState.html#Editable) and [`set_display_state`](struct.HexView.html#method.set_display_state) |
 
-extern crate cursive;
+extern crate cursive_core as cursive;
 extern crate itertools;
 
 use std::borrow::Borrow;


### PR DESCRIPTION
The stable core library behind cursive itself, that doesn't need a version
bump with every backend release.
